### PR TITLE
chore(uglify): Disable warnings

### DIFF
--- a/src/configure-webpack.js
+++ b/src/configure-webpack.js
@@ -26,7 +26,9 @@ export default (options) => ({
     ]
     .concat(options.production ? [
         new webpack.optimize.DedupePlugin(),
-        new webpack.optimize.UglifyJsPlugin(),
+        new webpack.optimize.UglifyJsPlugin({
+            compress: { warnings: false },
+        }),
     ] : [])
     .concat(options.plugins || []),
 


### PR DESCRIPTION
As noted in #22, the warnings are unnecessary and noisy.

Closes #22