### PR TITLE
feat(loaders): Include CSS and image loaders in the webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,13 +61,14 @@
     "react-router": "^2.4.0",
     "react-router-redux": "^4.0.4",
     "redux": "^3.5.2",
-    "webpack": "^2.1.0-beta.7",
+    "webpack": "^2.1.0-beta.13",
     "yargs": "^4.7.1"
   },
   "devDependencies": {
     "ava": "^0.15.1",
     "babel-cli": "^6.9.0",
     "babel-eslint": "^6.0.4",
+    "css-loader": "^0.23.1",
     "cz-conventional-changelog": "^1.1.6",
     "del": "^2.2.0",
     "del-cli": "^0.2.0",
@@ -76,8 +77,13 @@
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-import": "^1.8.1",
     "eventsource": "^0.2.1",
+    "file-loader": "^0.8.5",
     "mkdirp": "^0.5.1",
-    "semantic-release": "^4.3.5"
+    "node-sass": "^3.7.0",
+    "sass-loader": "^3.2.0",
+    "semantic-release": "^4.3.5",
+    "style-loader": "^0.13.1",
+    "url-loader": "^0.5.7"
   },
   "ava": {
     "babel": "inherit"

--- a/src/configure-webpack.js
+++ b/src/configure-webpack.js
@@ -39,10 +39,11 @@ export default (options) => ({
                 exclude: /node_modules/,
                 loader: 'babel-loader?' + JSON.stringify(babelrc),
             },
-            {
-                test: /\.json$/,
-                loader: 'json-loader',
-            },
+            { test: /\.json$/, loader: 'json' },
+            { test: /\.css$/, loaders: [ 'style', 'css' ] },
+            { test: /\.sass$/, loaders: [ 'style', 'css', 'sass?indentedSyntax' ] },
+            { test: /\.scss$/, loaders: [ 'style', 'css', 'sass' ] },
+            { test: /\.(gif|jpg|png)$/, loader: 'url?limit=25000' },
         ]
     },
 


### PR DESCRIPTION
Right now, if I need to use assets like images, CSS, or fonts, Webpack won't load them and include them in the bundle.  To make it possible to continue using Quik alongside these things, add the ability for the user to specify additional loaders to be included in the Webpack config.