### PR TITLE
fix: hardcode to use webpack v2.1.0-beta.22. refer #81

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
-    "webpack": "^2.1.0-beta.22",
+    "webpack": "2.1.0-beta.22",
     "yargs": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is meant to be a quick (not sustainable long term) for issue #81 